### PR TITLE
Pylint Error Fixed (no-value-for-parameter)

### DIFF
--- a/app.py
+++ b/app.py
@@ -107,7 +107,7 @@ class Entry(flask_db.Model):
         else:
             FTSEntry.insert({
                 FTSEntry.docid: self.id,
-                FTSEntry.content: content}).execute()
+                FTSEntry.content: content}, database=None).execute()
 
     @classmethod
     def public(cls):


### PR DESCRIPTION
There was an issue about pylint giving the error of _No value for argument 'database' in method call (no-value-for-parameter)_ for line 108 `FTSEntry.insert({` After searching the error (yes, the exact words), I came across this link: [.](https://github.com/coleifer/peewee/issues/1466) 
Coleifer made a flask blog tutorial that we used, and someone submitted a similar issue to ours. After showing Lesley, we decided to put `database=None` in the code. 
`FTSEntry.insert({
                FTSEntry.docid: self.id,
                FTSEntry.content: content}, database=None).execute()`

When I ran pylint, I got this message 
`Your code has been rated at 10.00/10`

Fixes #23  