### PR TITLE
Added a "Drafts" Button

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -52,6 +52,14 @@
         <!--<a class="nav-link" href="contact.html">Contact Us</a>-->
         <a class="nav-link" href="{{ url_for('contact') }}" target="">Contact Us</a>
       </li>
+      {% if session.logged_in %}
+      <li>
+        <a class="nav-link" href="{{ url_for('drafts') }}" target="">Drafts</a>
+      </li>
+      {% else %}
+        <!--<a class="nav-link" href="{{ url_for('drafts') }}" target="">Login</a>-->
+      {% endif %}
+
       <!--<li class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           Dropdown


### PR DESCRIPTION
Before, in order to access drafts, the user would have to know the URL of the draft OR go to learnercu.com/drafts. Because that is bad user experience (I did not know that link existed until Lesley pointed it out), I added a "Drafts" button to the navigation bar that only logged in users can access. When the user logs out, the "Drafts" button disappears.